### PR TITLE
Update react and object-assign packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   },
   "dependencies": {
     "clean-css": "^3.4.10",
-    "object-assign": "^4.0.1",
-    "react": "^0.14.6",
-    "react-dom": "^0.14.7",
+    "object-assign": "^4.1.0",
+    "react": "^15.0",
+    "react-dom": "^15.0",
     "sanitizer": "^0.1.3"
   },
   "devDependencies": {
@@ -28,7 +28,7 @@
     "eslint": "^2.4.0",
     "eslint-plugin-react": "^4.2.3",
     "jasmine": "^2.3.1",
-    "react-addons-test-utils": "^0.14.6"
+    "react-addons-test-utils": "^15.0"
   },
   "scripts": {
     "compile": "rm -rf lib/; babel -d lib/ src/",


### PR DESCRIPTION
This updates react to v15 and object-assign to v4.1 because of a bug in some versions of V8 that becomes apparent when using react v15.