### PR TITLE
Add react-dom as explicit dependency

### DIFF
--- a/examples/hello/package.json
+++ b/examples/hello/package.json
@@ -13,6 +13,7 @@
     "babel-preset-react": "^6.5.0",
     "express": "^4.12.3",
     "oy-vey": "../..",
-    "react": "^0.14.6"
+    "react": "^0.14.6",
+    "react-dom": "^0.14.6"
   }
 }


### PR DESCRIPTION
Since React 14.0 react-dom has been unbundled from react.  This will cause a clean instal of the example to fail with the following error.

```
Error: Cannot find module 'react-dom/server'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (server.js:3:1)
    at Module._compile (module.js:435:26)
    at loader (/Users/brian/Documents/oy/examples/hello/node_modules/babel-cli/node_modules/babel-register/lib/node.js:158:5)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/brian/Documents/oy/examples/hello/node_modules/babel-cli/node_modules/babel-register/lib/node.js:168:7)
Add react-dom as explicit dependency
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
```

This PR adds react-dom as an explicit dependency.