### PR TITLE
Upgrade React version

### DIFF
--- a/examples/hello/package.json
+++ b/examples/hello/package.json
@@ -13,7 +13,7 @@
     "babel-preset-react": "^6.5.0",
     "express": "^4.12.3",
     "oy-vey": "../..",
-    "react": "^0.14.6",
-    "react-dom": "^0.14.6"
+    "react": "~15.1.0",
+    "react-dom": "~15.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "clean-css": "^3.4.10",
     "object-assign": "^4.0.1",
-    "react": "^0.14.6",
-    "react-dom": "^0.14.7",
+    "react": "~15.1.0",
+    "react-dom": "~15.1.0",
     "sanitizer": "^0.1.3"
   },
   "devDependencies": {
@@ -28,7 +28,7 @@
     "eslint": "^2.4.0",
     "eslint-plugin-react": "^4.2.3",
     "jasmine": "^2.3.1",
-    "react-addons-test-utils": "^0.14.6"
+    "react-addons-test-utils": "~15.1.0"
   },
   "scripts": {
     "compile": "rm -rf lib/; babel -d lib/ src/",


### PR DESCRIPTION
Hi, thanks for your project! I have integrated with the non-alpha version of oy-vey and would like to upgrade to React 15. I noticed there was a previous PR for upgrading and am wondering if there any reason not to (at least until the `next` branch is non-alpha)?

Tests for printing a basic warning failed with version 15.2.0 due to an unknown props warning (https://facebook.github.io/react/warnings/unknown-prop.html), however tests passed fine for 15.1 so I've limited the upgrade to that version for now.