### PR TITLE
Added new PropType background to Table and TD elements

### DIFF
--- a/lib/components/DefaultElement.js
+++ b/lib/components/DefaultElement.js
@@ -8,6 +8,10 @@ var _objectAssign = require('object-assign');
 
 var _objectAssign2 = _interopRequireDefault(_objectAssign);
 
+var _BackgroundAbsoluteURLRule = require('../rules/BackgroundAbsoluteURLRule');
+
+var _BackgroundAbsoluteURLRule2 = _interopRequireDefault(_BackgroundAbsoluteURLRule);
+
 var _EmptyTDRule = require('../rules/EmptyTDRule');
 
 var _EmptyTDRule2 = _interopRequireDefault(_EmptyTDRule);
@@ -59,13 +63,16 @@ var _Element2 = _interopRequireDefault(_Element);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 // <table> element
+/**
+ * Provides default Oy.Element components with rules.
+ */
+
 var Table = function Table(props) {
   return (0, _Element2.default)((0, _objectAssign2.default)({}, props, { tagName: 'table' }));
-}; /**
-    * Provides default Oy.Element components with rules.
-    */
+};
 
 Table.propTypes = {
+  background: _BackgroundAbsoluteURLRule2.default,
   bgColor: _SixCharacterHexBackgroundColorRule2.default,
   border: _TableBorderRule2.default,
   cellPadding: _TableCellPaddingRule2.default,
@@ -104,6 +111,7 @@ var TD = function TD(props) {
 };
 
 TD.propTypes = {
+  background: _BackgroundAbsoluteURLRule2.default,
   bgColor: _SixCharacterHexBackgroundColorRule2.default,
   children: _EmptyTDRule2.default,
   style: _ShorthandFontRule2.default

--- a/lib/rules/BackgroundAbsoluteURLRule.js
+++ b/lib/rules/BackgroundAbsoluteURLRule.js
@@ -7,11 +7,11 @@ Object.defineProperty(exports, "__esModule", {
 // All we do is check for the presence of "http://" or "https://"
 // at the start of the string.
 
-var description = 'Relative src URLs can break (i.e. if recipients are outside the company network) and make your content unavailable to view.';
+var description = 'Relative background URLs can break (i.e. if recipients are outside the company network) and make your content unavailable to view.';
 
 exports.default = function (props) {
-  if (props.hasOwnProperty('src')) {
-    if (!/^https?:\/\//.test(props['src'])) {
+  if (props.hasOwnProperty('background')) {
+    if (!/^https?:\/\//.test(props['background'])) {
       return new Error(description);
     }
   }

--- a/lib/rules/__tests__/BackgroundAbsoluteURLRule-test.js
+++ b/lib/rules/__tests__/BackgroundAbsoluteURLRule-test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var _BackgroundAbsoluteURLRule = require('../BackgroundAbsoluteURLRule');
+
+var _BackgroundAbsoluteURLRule2 = _interopRequireDefault(_BackgroundAbsoluteURLRule);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+describe('BackgroundAbsoluteURLRule', function () {
+  it('should validate', function () {
+    var result1 = (0, _BackgroundAbsoluteURLRule2.default)({});
+    expect(result1 instanceof Error).toEqual(false);
+
+    var result2 = (0, _BackgroundAbsoluteURLRule2.default)({ background: 'foo' });
+    expect(result2 instanceof Error).toEqual(true);
+
+    var result3 = (0, _BackgroundAbsoluteURLRule2.default)({ background: '.' });
+    expect(result3 instanceof Error).toEqual(true);
+
+    var result4 = (0, _BackgroundAbsoluteURLRule2.default)({ background: '/foo' });
+    expect(result4 instanceof Error).toEqual(true);
+
+    var result5 = (0, _BackgroundAbsoluteURLRule2.default)({ background: '{HOMEPAGE_URL}' });
+    expect(result5 instanceof Error).toEqual(true);
+
+    var result6 = (0, _BackgroundAbsoluteURLRule2.default)({ background: '../foo.jpg' });
+    expect(result6 instanceof Error).toEqual(true);
+
+    var result7 = (0, _BackgroundAbsoluteURLRule2.default)({ background: 'https://www.example.com' });
+    expect(result7 instanceof Error).toEqual(false);
+
+    var result8 = (0, _BackgroundAbsoluteURLRule2.default)({ background: 'http://www.example.com' });
+    expect(result8 instanceof Error).toEqual(false);
+  });
+});

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -4,6 +4,15 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _BackgroundAbsoluteURLRule = require('./BackgroundAbsoluteURLRule');
+
+Object.defineProperty(exports, 'BackgroundAbsoluteURLRule', {
+  enumerable: true,
+  get: function get() {
+    return _interopRequireDefault(_BackgroundAbsoluteURLRule).default;
+  }
+});
+
 var _EmptyTDRule = require('./EmptyTDRule');
 
 Object.defineProperty(exports, 'EmptyTDRule', {

--- a/src/components/DefaultElement.jsx
+++ b/src/components/DefaultElement.jsx
@@ -4,6 +4,7 @@
 
 import objectAssign from 'object-assign';
 
+import BackgroundAbsoluteURLRule from '../rules/BackgroundAbsoluteURLRule';
 import EmptyTDRule from '../rules/EmptyTDRule';
 import HrefAbsoluteURLRule from '../rules/HrefAbsoluteURLRule';
 import ImgAltTextRule from '../rules/ImgAltTextRule';
@@ -25,6 +26,7 @@ const Table = (props) => {
 };
 
 Table.propTypes = {
+  background: BackgroundAbsoluteURLRule,
   bgColor: SixCharacterHexBackgroundColorRule,
   border: TableBorderRule,
   cellPadding: TableCellPaddingRule,
@@ -63,6 +65,7 @@ const TD = (props) => {
 };
 
 TD.propTypes = {
+  background: BackgroundAbsoluteURLRule,
   bgColor: SixCharacterHexBackgroundColorRule,
   children: EmptyTDRule,
   style: ShorthandFontRule

--- a/src/rules/BackgroundAbsoluteURLRule.js
+++ b/src/rules/BackgroundAbsoluteURLRule.js
@@ -1,0 +1,14 @@
+// This is a very simple test, and could be made more robust.
+// All we do is check for the presence of "http://" or "https://"
+// at the start of the string.
+
+const description = 'Relative background URLs can break (i.e. if recipients are outside the company network) and make your content unavailable to view.';
+
+
+export default (props) => {
+  if (props.hasOwnProperty('background')) {
+    if (!/^https?:\/\//.test(props['background'])) {
+      return new Error(description);
+    }
+  }
+};

--- a/src/rules/SrcAbsoluteURLRule.js
+++ b/src/rules/SrcAbsoluteURLRule.js
@@ -7,7 +7,7 @@ const description = 'Relative src URLs can break (i.e. if recipients are outside
 
 export default (props) => {
   if (props.hasOwnProperty('src')) {
-    if (!/^(http|https):\/\//.test(props['src'])) {
+    if (!/^https?:\/\//.test(props['src'])) {
       return new Error(description);
     }
   }

--- a/src/rules/__tests__/BackgroundAbsoluteURLRule-test.js
+++ b/src/rules/__tests__/BackgroundAbsoluteURLRule-test.js
@@ -1,0 +1,30 @@
+import rule from '../BackgroundAbsoluteURLRule';
+
+
+describe('BackgroundAbsoluteURLRule', function() {
+  it('should validate', function() {
+    const result1 = rule({});
+    expect(result1 instanceof Error).toEqual(false);
+
+    const result2 = rule({background: 'foo'});
+    expect(result2 instanceof Error).toEqual(true);
+
+    const result3 = rule({background: '.'});
+    expect(result3 instanceof Error).toEqual(true);
+
+    const result4 = rule({background: '/foo'});
+    expect(result4 instanceof Error).toEqual(true);
+
+    const result5 = rule({background: '{HOMEPAGE_URL}'});
+    expect(result5 instanceof Error).toEqual(true);
+
+    const result6 = rule({background: '../foo.jpg'});
+    expect(result6 instanceof Error).toEqual(true);
+
+    const result7 = rule({background: 'https://www.example.com'});
+    expect(result7 instanceof Error).toEqual(false);
+
+    const result8 = rule({background: 'http://www.example.com'});
+    expect(result8 instanceof Error).toEqual(false);
+  });
+});

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1,3 +1,4 @@
+export { default as BackgroundAbsoluteURLRule } from './BackgroundAbsoluteURLRule';
 export { default as EmptyTDRule } from './EmptyTDRule';
 export { default as HrefAbsoluteURLRule } from './HrefAbsoluteURLRule';
 export { default as ImgAltTextRule } from './ImgAltTextRule';


### PR DESCRIPTION
In order to enforce an absolute URL in the background attribute that is used when adding a background image support for multiple email clients.

Example -> https://blog.mailchimp.com/background-images-and-css-in-html-email/#comment-19940