### PR TITLE
Use PropTypes from prop-types package instead of React.PropTypes

### DIFF
--- a/examples/hello/modules/Footer.jsx
+++ b/examples/hello/modules/Footer.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {Table, TBody, TR, TD, A} from 'oy-vey';
 
 import EmptySpace from './EmptySpace.jsx';
@@ -103,7 +104,7 @@ const Footer = (props) => {
 };
 
 Footer.propTypes = {
-  color: React.PropTypes.string.isRequired
+  color: PropTypes.string.isRequired
 };
 
 

--- a/examples/hello/modules/Header.jsx
+++ b/examples/hello/modules/Header.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {Table, TBody, TD, TR} from 'oy-vey';
 
 import EmptySpace from './EmptySpace.jsx';
@@ -42,7 +43,7 @@ const Header = (props) => {
 };
 
 Header.propTypes = {
-  color: React.PropTypes.string.isRequired
+  color: PropTypes.string.isRequired
 };
 
 

--- a/lib/components/Element.js
+++ b/lib/components/Element.js
@@ -8,6 +8,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _objectAssign = require('object-assign');
 
 var _objectAssign2 = _interopRequireDefault(_objectAssign);
@@ -27,7 +31,7 @@ var Element = function Element(props) {
 };
 
 Element.propTypes = {
-  tagName: _react2.default.PropTypes.string.isRequired
+  tagName: _propTypes2.default.string.isRequired
 };
 
 exports.default = Element;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint": "^2.4.0",
     "eslint-plugin-react": "^4.2.3",
     "jasmine": "^2.3.1",
+    "prop-types": "^15.5.8",
     "react": "^15.4.0",
     "react-addons-test-utils": "^15.4.0",
     "react-dom": "^15.4.0"

--- a/src/components/Element.jsx
+++ b/src/components/Element.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import objectAssign from 'object-assign';
 
 import OyProps from './OyProps';
@@ -17,7 +18,7 @@ const Element = (props) => {
 };
 
 Element.propTypes = {
-  tagName: React.PropTypes.string.isRequired
+  tagName: PropTypes.string.isRequired
 };
 
 


### PR DESCRIPTION
`Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.`

React.PropTypes is deprecated since 15.5 and will be removed in the future.