### PR TITLE
Import react-dom/server.browser so we can render email in the browser

### DIFF
--- a/lib/utils/Renderer.js
+++ b/lib/utils/Renderer.js
@@ -12,7 +12,7 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _server = require('react-dom/server');
+var _server = require('react-dom/server.browser');
 
 var _server2 = _interopRequireDefault(_server);
 

--- a/src/utils/Renderer.js
+++ b/src/utils/Renderer.js
@@ -1,6 +1,6 @@
 import CleanCSS from 'clean-css';
 import React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import ReactDOMServer from 'react-dom/server.browser';
 import objectAssign from 'object-assign';
 import sanitizer from 'sanitizer';
 


### PR DESCRIPTION
I want to render emails in the browser while designing, but Oy imports ReactDOMServer which imports the `fs` module for the purpose of `renderToNodeStream()` and `renderToStaticNodeStream()` which this project isn't even using.