### PR TITLE
Fix types to be compatible with @types/react@16.4.18

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ declare namespace Oy {
   interface OyElementAttributes {
     width?: number | string;
     height?: number | string;
-    align?: string;
+    align?: 'left' | 'center' | 'right' | 'justify' | 'char';
     background?: string;
     bgcolor?: string;
     border?: number | string;


### PR DESCRIPTION
Fixes:
```
node_modules/oy-vey/index.d.ts:51:13 - error TS2320: Interface 'OyTDElementAttributes' cannot simultaneously extend types 'TdHTMLAttributes<HTMLTableDataCellElement>' and 'OyElementAttributes'.
  Named property 'align' of types 'TdHTMLAttributes<HTMLTableDataCellElement>' and 'OyElementAttributes' are not identical.
```

After updating to `@types/react@16.4.18`

The new version of react type has more precise typing for the `align` attribute.