### PR TITLE
Update OyElementAttributes TS type to match React type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ declare namespace Oy {
     background?: string;
     bgcolor?: string;
     border?: number | string;
-    valign?: string;
+    valign?: 'top' | 'middle' | 'bottom' | 'baseline';
   }
 
   interface OyTBodyElementAttributes


### PR DESCRIPTION
The type definition for `OyElementAttributes` does not match [React's TS definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f0016483a4b1d1fd6fd636c47eea19e2d1614336/types/react/index.d.ts#L2198) for `TdHTMLAttributes<HTMLTableDataCellElement> ` as of `@types/react` 16.9. This causes errors like:

```
node_modules/oy-vey/index.d.ts:51:13 - error TS2320: Interface 'OyTDElementAttributes' cannot simultaneously extend types 'TdHTMLAttributes<HTMLTableDataCellElement>' and 'OyElementAttributes'.
  Named property 'valign' of types 'TdHTMLAttributes<HTMLTableDataCellElement>' and 'OyElementAttributes' are not identical.

51   interface OyTDElementAttributes
               ~~~~~~~~~~~~~~~~~~~~~
```

This PR updates Oy's type definition to satisfy React's expectations.