### PR TITLE
Add react 18 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "sanitizer": "^0.1.3"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || ^17.0.0",
-    "react-dom": "^16.0.0 || ^17.0.0"
+    "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
This repository only uses one method in react-dom, which is `renderToStaticMarkup`, along with rendering a few basic components. `renderToStaticMarkup` doesn't behave differently on React 18 vs 17, so I believe it's safe to include the new React version into this project's peer dependencies.